### PR TITLE
Fix deserialization of classes contained in a container

### DIFF
--- a/src/main/java/com/tyler/gson/immutable/Types.java
+++ b/src/main/java/com/tyler/gson/immutable/Types.java
@@ -9,41 +9,44 @@ import com.google.common.base.Optional;
 import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
 
-@SuppressWarnings ( {"unchecked", "serial"} ) 
+@SuppressWarnings({"unchecked", "serial"})
 public class Types {
-	
-	public static <K,V> TypeToken<Map<K,V>> mapOf(final Type key, final Type value) {
-		return new TypeToken<Map<K,V>>() {}
-		.where( newTypeParameter(), typeTokenOf( key ))		
-		.where( newTypeParameter(), typeTokenOf( value ));   
-	}
-	
-	public static <K,V> TypeToken<HashMap<K,V>> hashmapOf(final Type key, final Type value) {
-		return new TypeToken<HashMap<K,V>>() {}
-		.where( newTypeParameter(), typeTokenOf( key ))		
-		.where( newTypeParameter(), typeTokenOf( value ));   
-	}
-	
-	public static <E> TypeToken<Collection<E>> collectionOf( final Type type ){
-		return new TypeToken<Collection<E>>(){}
-			.where( newTypeParameter(), typeTokenOf( type ));
-	}
-	
-	public static <E> TypeToken<Optional<E>> optionalOf( final Type type ){
-		return new TypeToken<Optional<E>>(){}
-		.where( newTypeParameter(), typeTokenOf( type ) );
-	}
-	
-	public static <E> TypeToken<E> parametrizedOf( final Class<E> clazz, final Type type ){
-		return new TypeToken<E>( clazz ){}
-		.where( newTypeParameter(), typeTokenOf( type ) );
-	}
-	
-	private static <E> TypeParameter<E> newTypeParameter(){
-		return new TypeParameter<E>(){};
-	}
-	
-	private static <E> TypeToken<E> typeTokenOf( final Type type ){
-		return (TypeToken<E>) TypeToken.of( type );
-	}
+
+  public static <K, V> TypeToken<Map<K, V>> mapOf(final Type key, final Type value) {
+    TypeParameter<K> newKeyTypeParameter = new TypeParameter<K>() {};
+    TypeParameter<V> newValueTypeParameter = new TypeParameter<V>() {};
+    return new TypeToken<Map<K, V>>() {}
+        .where(newKeyTypeParameter, Types.<K>typeTokenOf(key))
+        .where(newValueTypeParameter, Types.<V>typeTokenOf(value));
+  }
+
+  public static <K, V> TypeToken<HashMap<K, V>> hashmapOf(final Type key, final Type value) {
+    TypeParameter<K> newKeyTypeParameter = new TypeParameter<K>() {};
+    TypeParameter<V> newValueTypeParameter = new TypeParameter<V>() {};
+    return new TypeToken<HashMap<K, V>>() {}
+        .where(newKeyTypeParameter, Types.<K>typeTokenOf(key))
+        .where(newValueTypeParameter, Types.<V>typeTokenOf(value));
+  }
+
+  public static <E> TypeToken<Collection<E>> collectionOf(final Type type) {
+    TypeParameter<E> newTypeParameter = new TypeParameter<E>() {};
+    return new TypeToken<Collection<E>>() {}
+        .where(newTypeParameter, Types.<E>typeTokenOf(type));
+  }
+
+  public static <E> TypeToken<Optional<E>> optionalOf(final Type type) {
+    TypeParameter<E> newTypeParameter = new TypeParameter<E>() {};
+    return new TypeToken<Optional<E>>() {}
+        .where(newTypeParameter, Types.<E>typeTokenOf(type));
+  }
+
+  public static <E> TypeToken<E> parametrizedOf(final Class<E> clazz, final Type type) {
+    TypeParameter<E> newTypeParameter = new TypeParameter<E>() {};
+    return new TypeToken<E>(clazz) {}
+        .where(newTypeParameter, Types.<E>typeTokenOf(type));
+  }
+
+  private static <E> TypeToken<E> typeTokenOf(final Type type) {
+    return (TypeToken<E>) TypeToken.of(type);
+  }
 }

--- a/src/test/java/com/tyler/gson/immutable/ImmutableListDeserializerTest.java
+++ b/src/test/java/com/tyler/gson/immutable/ImmutableListDeserializerTest.java
@@ -1,9 +1,10 @@
 package com.tyler.gson.immutable;
 
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.Iterables;
 import java.util.List;
 
 import org.hamcrest.core.Is;
@@ -16,51 +17,58 @@ import com.google.gson.GsonBuilder;
 public class ImmutableListDeserializerTest {
 	private final ImmutableList<String> testList = ImmutableList.of( "a", "b", "c" );
 	private final String json = "{ \"list\" : [\"a\", \"b\", \"c\" ] }";
-	
+
 	@Test
-	public void testDeserializeImmutableInterface_1() {
+	public void testDeserializeImmutableInterface() {
 		final Gson gson = new GsonBuilder().registerTypeAdapter(ImmutableList.class, new ImmutableListDeserializer()).create();
 		final ImmutableInterface tester = gson.fromJson( json, ImmutableInterface.class );
-		
-		assertThat( tester.list, Is.is( testList ));		
+
+		assertThat( tester.list, Is.is( testList ));
 	}
-	
-	@Test( expected = ClassCastException.class )
-	public void testDeserializeImmutableInterface_2() {
-		final Gson gson = new GsonBuilder().registerTypeAdapter(ImmutableList.class, new ImmutableListDeserializer()).create();
-		ImmutableInterface tester = gson.fromJson( "{ \"list\" : [1,2,3] }", ImmutableInterface.class );
-		assertNotNull( tester.list.get(0 ).getClass() );
-	}
-	
+
 	@Test
-	public void testDeserializeImplemntation_1() {
+	public void testDeserializeImplementation() {
 		final Gson gson = new GsonBuilder().registerTypeAdapter(List.class, new ImmutableListDeserializer()).create();
 		final ImmutableImplementation tester = gson.fromJson( json, ImmutableImplementation.class );
-		
-		assertThat( tester.list, Is.is( (List<String>)testList ));		
-	}
-	
-	@Test( expected = ClassCastException.class )
-	public void testDeserializeImmutableImplemntation_2() {
-		final Gson gson = new GsonBuilder().registerTypeAdapter(List.class, new ImmutableListDeserializer()).create();
-		ImmutableImplementation tester = gson.fromJson( "{ \"list\" : [1,2,3] }", ImmutableImplementation.class );
 
-		assertNotNull( tester.list.get(0 ).getClass() );
+		assertThat( tester.list, Is.is( (List<String>)testList ));
 	}
-		
-	private static final class ImmutableInterface { 
+
+	@Test
+  public void testDeserializeNested() {
+	  final Gson gson = new GsonBuilder().registerTypeAdapter(List.class, new ImmutableListDeserializer()).create();
+	  final Parent tester = gson.fromJson("{'list': [{'name':'nested'}]}",Parent.class);
+
+	  assertEquals(Iterables.getOnlyElement(tester.list).name, "nested");
+  }
+
+	private static final class ImmutableInterface {
 		private final ImmutableList<String> list;
-		
+
 		private ImmutableInterface(){
 			this.list = ImmutableList.of();
-		}		
+		}
 	}
-	
-	private static final class ImmutableImplementation { 
+
+	private static final class ImmutableImplementation {
 		private final List<String> list;
-		
+
 		private ImmutableImplementation(){
 			this.list = ImmutableList.of();
-		}		
+		}
+	}
+
+	private static class Parent {
+		private List<Nested> list;
+
+    private static class Nested {
+      private String name;
+
+      public boolean equals(Object other) {
+        if(!(other instanceof Nested))
+          return false;
+        return name.equals(((Nested) other).name);
+      }
+    }
 	}
 }

--- a/src/test/java/com/tyler/gson/immutable/ImmutableSetDeserializerTest.java
+++ b/src/test/java/com/tyler/gson/immutable/ImmutableSetDeserializerTest.java
@@ -1,7 +1,7 @@
 package com.tyler.gson.immutable;
 
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.util.Set;
@@ -10,59 +10,64 @@ import org.hamcrest.core.Is;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 public class ImmutableSetDeserializerTest {
 	private final ImmutableSet<String> testSet = ImmutableSet.of( "a", "b", "c" );
 	private final String json = "{ \"set\" : [\"a\", \"b\", \"c\" ] }";
-	
+
 	@Test
-	public void testDeserializeImmutableInterface_1() {
+	public void testDeserializeImmutableInterface() {
 		final Gson gson = new GsonBuilder().registerTypeAdapter(ImmutableSet.class, new ImmutableSetDeserializer()).create();
 		final ImmutableInterface tester = gson.fromJson( json, ImmutableInterface.class );
-		
-		assertThat( tester.set, Is.is( testSet ));		
+
+		assertThat( tester.set, Is.is( testSet ));
 	}
-	
-	@Test( expected = ClassCastException.class )
-	public void testDeserializeImmutableInterface_2() {
-		final Gson gson = new GsonBuilder().registerTypeAdapter(ImmutableSet.class, new ImmutableSetDeserializer()).create();
-		ImmutableInterface tester = gson.fromJson( "{ \"set\" : [1,2,3] }", ImmutableInterface.class );	
-		
-		assertNotNull( Iterables.get( tester.set, 0).getClass() );
-	}
-	
+
 	@Test
-	public void testDeserializeImplemntation_1() {
+	public void testDeserializeImplementation() {
 		final Gson gson = new GsonBuilder().registerTypeAdapter(Set.class, new ImmutableSetDeserializer()).create();
 		final ImmutableImplementation tester = gson.fromJson( json, ImmutableImplementation.class );
-		
-		assertThat( tester.set, Is.is( (Set<String>)testSet ));		
+
+		assertThat( tester.set, Is.is( (Set<String>)testSet ));
 	}
-	
-	@Test( expected = ClassCastException.class )
-	public void testDeserializeImmutableImplemntation_2() {
+
+	@Test
+	public void testDeserializeNested() {
 		final Gson gson = new GsonBuilder().registerTypeAdapter(Set.class, new ImmutableSetDeserializer()).create();
-		ImmutableImplementation tester = gson.fromJson( "{ \"set\" : [1,2,3] }", ImmutableImplementation.class );
-		
-		assertNotNull( Iterables.get( tester.set, 0).getClass() );
+		final Parent tester = gson.fromJson("{'set': [{'name':'nested'}]}",Parent.class);
+
+		assertEquals(tester.set.iterator().next().name, "nested");
 	}
-		
-	private static final class ImmutableInterface { 
+
+	private static final class ImmutableInterface {
 		private final ImmutableSet<String> set;
-		
+
 		private ImmutableInterface(){
 			this.set = ImmutableSet.of();
-		}		
+		}
 	}
-	
-	private static final class ImmutableImplementation { 
+
+	private static final class ImmutableImplementation {
 		private final Set<String> set;
-		
+
 		private ImmutableImplementation(){
 			this.set = ImmutableSet.of();
-		}		
+		}
+	}
+
+	private static class Parent {
+		private Set<Nested> set;
+
+		private static class Nested {
+			private String name;
+
+			public boolean equals(Object other) {
+				if(!(other instanceof Nested))
+					return false;
+				return name.equals(((Nested) other).name);
+			}
+		}
 	}
 }

--- a/src/test/java/com/tyler/gson/immutable/ImmutableSortedSetDeserializerTest.java
+++ b/src/test/java/com/tyler/gson/immutable/ImmutableSortedSetDeserializerTest.java
@@ -2,7 +2,6 @@ package com.tyler.gson.immutable;
 
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import java.util.Set;
@@ -38,15 +37,7 @@ public class ImmutableSortedSetDeserializerTest {
 		assertEquals( Iterables.get( tester.set, 1), "b" );
 		assertEquals( Iterables.get( tester.set, 2), "c" );
 	}
-	
-	@Test( expected = ClassCastException.class )
-	public void testDeserializeImmutableInterface_3() {
-		final Gson gson = new GsonBuilder().registerTypeAdapter(ImmutableSortedSet.class, new ImmutableSortedSetDeserializer()).create();
-		ImmutableInterface tester = gson.fromJson( "{ \"set\" : [1,2,3] }", ImmutableInterface.class );	
-		
-		assertNotNull( Iterables.get( tester.set, 0).getClass() );
-	}
-	
+
 	@Test
 	public void testDeserializeImplemntation_1() {
 		final Gson gson = new GsonBuilder().registerTypeAdapter(SortedSet.class, new ImmutableSortedSetDeserializer()).create();
@@ -64,18 +55,8 @@ public class ImmutableSortedSetDeserializerTest {
 		assertEquals( Iterables.get( tester.set, 1), "b" );
 		assertEquals( Iterables.get( tester.set, 2), "c" );
 	}
-	
-	@Test( expected = ClassCastException.class )
-	public void testDeserializeImmutableImplemntation_3() {
-		final Gson gson = new GsonBuilder().registerTypeAdapter(SortedSet.class, new ImmutableSortedSetDeserializer()).create();
-		ImmutableImplementation tester = gson.fromJson( "{ \"set\" : [1,2,3] }", ImmutableImplementation.class );
-		
-		assertNotNull( Iterables.get( tester.set, 0).getClass() );		
-	}
-		
-	
-	
-	private static final class ImmutableInterface { 
+
+	private static final class ImmutableInterface {
 		private final ImmutableSortedSet<String> set;
 		
 		private ImmutableInterface(){


### PR DESCRIPTION
Move construction of TypeParameter to corresponding method to allow
proper capture of the type parameter context.

Fixes #4